### PR TITLE
Makefile:  fix for MacOS Bash not supporting globstar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .DEFAULT_GOAL := help
 
-SHELL = /bin/bash -O globstar
-
 DESTDIR ?= /usr/local
 GPL2 ?= false
 
@@ -13,14 +11,18 @@ endif
 GO111MODULE=on
 export GO111MODULE
 
+
 .PHONY: help
 help:
 	@echo "Usage: make [target]"
 	@cat Makefile | awk -F ":.*##"  '/##/ { printf "    %-17s %s\n", $$1, $$2 }' | grep -v  grep
 
+rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+C_FILES := $(call rwildcard,.,*.c)
+H_FILES := $(call rwildcard,.,*.h)
 .PHONY: format-c
-format-c: ## formats all the C code
-	clang-format --style=file -i **/*.c **/*.h
+format-c: $(C_FILES) $(H_FILES) ## formats all the C code
+	clang-format --style=file -i $^
 
 .PHONY: format-c-check
 format-c-check: ## checks C code formatting


### PR DESCRIPTION
As of 30 SEP 2022, MacOS's default bash installation does not support globstar, so the previous makefile's fails to run.  This replaces the need for globstar with a pure make alternative.

I'm no makefile expert, and part of me wonders if this is worth it, but it is pretty annoying to have this fail on MacOS.

Fixes #19