### PR TITLE
GNUmakefile:  link against glibc not musl

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -104,10 +104,10 @@ endif
 	git checkout $(TAG)
 
 ##	linux_amd64
-	CGO_ENABLED=1 CC="${ZIG} cc -target x86_64-linux" GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -buildmode c-shared -o .build/uplink_linux_amd64.so .
+	CGO_ENABLED=1 CC="${ZIG} cc -target x86_64-linux-gnu" GOARCH=amd64 GOOS=linux go build -ldflags="-s -w" -buildmode c-shared -o .build/uplink_linux_amd64.so .
 	github-release upload --user storj --repo uplink-c --tag "$(TAG)" --name "uplink_linux_amd64.so" --file ".build/uplink_linux_amd64.so"
 ##	linux_arm64
-	CGO_ENABLED=1 CC="${ZIG} cc -target aarch64-linux" GOOS=linux go build -ldflags="-s -w" -buildmode c-shared -o .build/uplink_linux_arm64.so .
+	CGO_ENABLED=1 CC="${ZIG} cc -target aarch64-linux-gnu" GOOS=linux go build -ldflags="-s -w" -buildmode c-shared -o .build/uplink_linux_arm64.so .
 	github-release upload --user storj --repo uplink-c --tag "$(TAG)" --name "uplink_linux_arm64.so" --file ".build/uplink_linux_arm64.so"
 ##	windows_amd64
 	CGO_ENABLED=1 CC="${ZIG} cc -target x86_64-windows" GOARCH=amd64 GOOS=windows go build -ldflags="-s -w" -buildmode c-shared -o .build/uplink_windows_amd64.dll .


### PR DESCRIPTION
The linker commands for the release process were creating MUSL libc builds (Alpine Linux) not typical GNU builds, for a typical install.

Tested via:

% CGO_ENABLED=1 CC="${ZIG} cc -target x86_64-linux-gnu" GOARCH=amd64
  GOOS=linux go build -ldflags="-s -w" -buildmode c-shared -o
  .build/uplink_linux_amd64.so .
% CGO_ENABLED=1 CC="${ZIG} cc -target aarch64-linux-gnu" GOOS=linux go
  build -ldflags="-s -w" -buildmode c-shared -o
  .build/uplink_linux_arm64.so .

% docker run --platform linux/amd64 --rm -v ./:/host -ti ubuntu bash root@7f4873dfabf4:/# ldd host/.build/uplink_linux_amd64.so
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6
        libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2
        /lib64/ld-linux-x86-64.so.2

% docker run --platform linux/arm64 --rm -v ./:/host -ti ubuntu bash root@10b5016ea2e8:/# ldd host/.build/uplink_linux_arm64.so
        linux-vdso.so.1
        libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6
        libresolv.so.2 => /lib/aarch64-linux-gnu/libresolv.so.2
        /lib/ld-linux-aarch64.so.1