### PR TITLE
bug: Fix `scripts/version` on macOS

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -7,8 +7,7 @@ if [ $(git describe --tags --exact-match --match 'v[0-9]*.[0-9]*.[0-9]*' &>/dev/
   version=$(git describe --tags --exact-match --match 'v[0-9]*.[0-9]*.[0-9]*')
 fi
 
-if [ $(expr match "${version}" '^v') -eq 1 ]; then
-  printf '%s\n' $(expr substr "${version}" 2 $(expr length "${version}"))
-else
-  printf '%s\n' "${version}"
-fi
+case "$version" in
+  v*) echo "${version#v}" ;;
+  *) echo "$version" ;;
+esac


### PR DESCRIPTION
The following fails when trying to run on macOS (simplified):

```bash
    version='0.0.0'
    expr match "${version}" '^v'
    # expr: syntax error
```

This changes the script to work with different sh syntax.