### PR TITLE
build: Make `build` target cross-compile capable

### DIFF
--- a/.github/workflows/cross-build-check.yaml
+++ b/.github/workflows/cross-build-check.yaml
@@ -1,0 +1,90 @@
+name: Cross build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  cross-build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [arm64, riscv64, loong64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v1
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.2'
+      - name: Run make build
+        env:
+          GOARCH: ${{ matrix. goarch }}
+        run: make build
+
+  cross-build-darwin-to-linux:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        goarch: [amd64, arm64, riscv64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v1
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.2'
+      - name: Run make build
+        env:
+          GOARCH: ${{ matrix. goarch }}
+          GOOS: linux
+        run: make build
+
+  cross-build-linux-to-windows:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v1
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.2'
+      - name: Run make build
+        env:
+          GOARCH: ${{ matrix. goarch }}
+          GOOS: windows
+        run: make build
+
+  cross-build-windows-to-linux:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v1
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.2'
+      - name: Install make on Windows
+        run: choco install make
+        shell: powershell
+      - name: Run make build
+        env:
+          GOARCH: ${{ matrix. goarch }}
+          GOOS: linux
+        run: make build

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ C library for Storj V3 Network.
 Storj is building a decentralized cloud storage network.
 [Check out our white paper for more info!](https://storj.io/white-paper)
 
-----
+---
 
 Storj is an S3-compatible platform and suite of decentralized applications that
 allows you to store data in a secure and decentralized manner. Your files are
@@ -37,6 +37,22 @@ dependencies (sadly, Apache v2 is incompatible with the GPLv2). Currently this
 results in slower hashing performance (no github.com/minio/sha256-simd) and
 reduced debugging and analysis infrastructure.
 
+## Cross-Compilation
+
+Cross-compilation is supported. The [`zig`](https://ziglang.org) compiler is required.
+
+After all pre-requisites are installed, cross-compile by executing:
+
+```sh
+GOARCH="target-arch" GOOS="target-os" make build
+```
+
+For example, to cross-compile to an ARM64 Linux target:
+
+```sh
+GOARCH="arm64" GOOS="linux" make build
+```
+
 # API Documentation
 
 Documentation of the stable C API is at [storj.github.io/uplink-c](https://storj.github.io/uplink-c/)
@@ -54,8 +70,8 @@ them unless they mention it explicitly.
 
 In summary:
 
-* The caller owns the data.
-* Some functions allocate on behalf of the caller (in which case there's a
+- The caller owns the data.
+- Some functions allocate on behalf of the caller (in which case there's a
   corresponding free that needs to be called).
 
 # Examples

--- a/scripts/build-lib
+++ b/scripts/build-lib
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+_print_usage() {
+	echo "Usage: $0 OUT_DIR"
+}
+
+if [ -z "$1" ]; then
+	_print_usage
+	exit 1
+fi
+OUT_DIR=$1
+
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+ZIG=$(which zig)
+
+HOST_GOOS=$(uname | tr '[:upper:]' '[:lower:]')
+HOST_GOARCH=$(uname -m)
+
+# Darwin (macOS) does not support cross-compilation from other OS's.
+if [ "${GOOS}" = "darwin" ]; then
+	if [ "${HOST_GOOS}" != "darwin" ]; then
+		echo "Cannot cross-compile from $HOST_GOOS to $GOOS."
+		exit 1
+	fi
+fi
+
+# Normalize HOST_GOARCH
+if [ "${HOST_GOARCH}" = "x86_64" ]; then
+	HOST_GOARCH="amd64"
+elif [ "${HOST_GOARCH}" = "aarch64" ]; then
+	HOST_GOARCH="arm64"
+elif [ "${HOST_GOARCH}" = "loongarch64" ]; then
+	HOST_GOARCH="loong64"
+fi
+
+# Initialize variables
+OUT_SHARED_NAME="uplink.so"
+OUT_STATIC_NAME="uplink.a"
+CC_TARGET=""
+
+if [ "$GOOS-$GOARCH" = "$HOST_GOOS-$HOST_GOARCH" ]; then
+	CC_TARGET=""
+	case "$GOOS" in
+		darwin)
+			OUT_SHARED_NAME="uplink.dylib"
+			;;
+		windows)
+			OUT_SHARED_NAME="uplink.dll"
+			OUT_STATIC_NAME="uplink.lib"
+			;;
+	esac
+else
+	if [ -z "$ZIG" ]; then
+		echo "Zig compiler not found"
+		exit 1
+	fi
+
+	echo "Cross-compiling to target: $GOOS-$GOARCH (host: $HOST_GOOS-$HOST_GOARCH)"
+
+	CC_ARCH=""
+	case "$GOARCH" in
+		amd64) CC_ARCH="x86_64" ;;
+		arm64) CC_ARCH="aarch64" ;;
+		riscv64) CC_ARCH="riscv64" ;;
+		loong64) CC_ARCH="loongarch64" ;;
+		*)
+			echo "Unsupported cross-compilation target: GOOS=$GOOS GOARCH=$GOARCH" >&2
+			exit 1
+			;;
+	esac
+
+	case "$GOOS" in
+		linux) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-linux-gnu" ;;
+		darwin)
+			# Native compilation is required for MacOS
+			CC_TARGET=""
+			OUT_SHARED_NAME="uplink.dylib"
+			;;
+		windows)
+			CC_TARGET="${ZIG} cc -target ${CC_ARCH}-windows-gnu"
+			OUT_SHARED_NAME="uplink.dll"
+			OUT_STATIC_NAME="uplink.lib"
+			;;
+		js) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-wasi" ;;
+		*) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-${GOOS}" ;;
+	esac
+fi
+
+OUT_SHARED_PATH="$OUT_DIR/$OUT_SHARED_NAME"
+OUT_STATIC_PATH="$OUT_DIR/$OUT_STATIC_NAME"
+
+if [ -z "$CC_TARGET" ]; then
+	set -e -x
+	CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode c-shared -o "$OUT_SHARED_PATH" .
+	CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode c-archive -o "$OUT_STATIC_PATH" .
+else
+	set -e -x
+	CGO_ENABLED=1 CC="$CC_TARGET" go build -ldflags="-s -w" -buildmode c-shared -o "$OUT_SHARED_PATH" .
+	CGO_ENABLED=1 CC="$CC_TARGET" go build -ldflags="-s -w" -buildmode c-archive -o "$OUT_STATIC_PATH" .
+fi


### PR DESCRIPTION
This change makes `make build` capable of cross-compiling. This can be useful for external libraries.

Partially addresses https://github.com/storj-thirdparty/uplink-rust/issues/87, which previously could not cross-compile.

To use or test the cross-compilation ability:

```sh
GOARCH=arm64 GOOS="linux" make build
```
