### PR TITLE
build: Make build target cross-compile capable

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [x86_64, aarch64, loongarch64, powerpc64le, wasm]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v1
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.2'
+
+      - name: Install make on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install make
+        shell: powershell
+
+      - name: Run make build
+        run: make build

--- a/.github/workflows/cross-build-check.yaml
+++ b/.github/workflows/cross-build-check.yaml
@@ -7,12 +7,11 @@ on:
   pull_request:
 
 jobs:
-  cross-build-no-darwin:
+  cross-build-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goarch: [arm64, amd64, riscv, riscv64, loong64, ppc, ppcle, ppc64, ppc64le, mips, mipsle, misp64, wasm]
-        goos: [js, linux, windows]
+        goarch: [arm64, riscv64, loong64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,25 +21,50 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '~1.24.2'
-      - name: Install make on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install make
-        shell: powershell
-
       - name: Run make build
         env:
           GOARCH: ${{ matrix. goarch }}
-          GOOS: ${{ matrix. goos }}
         run: make build
-  cross-build-darwin:
+
+  cross-build-darwin-to-linux:
     runs-on: macos-latest
     strategy:
       matrix:
-        # We could use the same list as the cross-build-no-darwin job, but we dropped the unusual
-        # architectures to reduce checking time.
-        goarch: [arm64, amd64, wasm]
-        goos: [darwin, js, linux, windows]
+        goarch: [amd64, arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v1
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.2'
+      - name: Run make build
+        env:
+          GOARCH: ${{ matrix. goarch }}
+          GOOS: linux
+        run: make build
+
+  cross-build-linux-to-windows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v1
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.2'
+      - name: Run make build
+        env:
+          GOARCH: amd64
+          GOOS: windows
+        run: make build
+
+  cross-build-windows-to-linux:
+    runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,13 +75,10 @@ jobs:
         with:
           go-version: '~1.24.2'
       - name: Install make on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install make
+        run: choco install make
         shell: powershell
-
       - name: Run make build
         env:
-          GOARCH: ${{ matrix. goarch }}
-          GOOS: ${{ matrix. goos }}
+          GOARCH: amd64
+          GOOS: linux
         run: make build

--- a/.github/workflows/cross-build-check.yaml
+++ b/.github/workflows/cross-build-check.yaml
@@ -8,15 +8,11 @@ on:
 
 jobs:
   cross-build:
-    runs-on: unbuntu-latest
-   # strategy:
-   #   matrix:
-   #     # Ideally would test all the combinations, but this is quite slow and overwhelm Github, so
-   #     # we use a subset.
-   #     # goarch: [arm64, amd64, riscv, riscv64, loong64, ppc, ppcle, ppc64, ppc64le, mips, mipsle, misp64, wasm]
-   #     # goos: [darwin, js, linux, windows]
-   #     goarch: [arm64, amd64]
-   #     goos: [darwin, linux, windows]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [arm64, amd64, riscv, riscv64, loong64, ppc, ppcle, ppc64, ppc64le, mips, mipsle, misp64, wasm]
+        goos: [darwin, js, linux, windows]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,8 +30,6 @@ jobs:
 
       - name: Run make build
         env:
-        #  GOARCH: ${{ matrix. goarch }}
-        #  GOOS: ${{ matrix. goos }}
-          GOARCH: arm64
-          GOOS: darwin
+          GOARCH: ${{ matrix. goarch }}
+          GOOS: ${{ matrix. goos }}
         run: make build

--- a/.github/workflows/cross-build-check.yaml
+++ b/.github/workflows/cross-build-check.yaml
@@ -7,11 +7,39 @@ on:
   pull_request:
 
 jobs:
-  cross-build:
+  cross-build-no-darwin:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         goarch: [arm64, amd64, riscv, riscv64, loong64, ppc, ppcle, ppc64, ppc64le, mips, mipsle, misp64, wasm]
+        goos: [js, linux, windows]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v1
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.24.2'
+      - name: Install make on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install make
+        shell: powershell
+
+      - name: Run make build
+        env:
+          GOARCH: ${{ matrix. goarch }}
+          GOOS: ${{ matrix. goos }}
+        run: make build
+  cross-build-darwin:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # We could use the same list as the cross-build-no-darwin job, but we dropped the unusual
+        # architectures to reduce checking time.
+        goarch: [arm64, amd64, wasm]
         goos: [darwin, js, linux, windows]
     steps:
       - name: Checkout code

--- a/.github/workflows/cross-build-check.yaml
+++ b/.github/workflows/cross-build-check.yaml
@@ -9,14 +9,14 @@ on:
 jobs:
   cross-build:
     runs-on: unbuntu-latest
-    strategy:
-      matrix:
-        # Ideally would test all the combinations, but this is quite slow and overwhelm Github, so
-        # we use a subset.
-        # goarch: [arm64, amd64, riscv, riscv64, loong64, ppc, ppcle, ppc64, ppc64le, mips, mipsle, misp64, wasm]
-        # goos: [darwin, js, linux, windows]
-        goarch: [arm64, amd64]
-        goos: [darwin, linux, windows]
+   # strategy:
+   #   matrix:
+   #     # Ideally would test all the combinations, but this is quite slow and overwhelm Github, so
+   #     # we use a subset.
+   #     # goarch: [arm64, amd64, riscv, riscv64, loong64, ppc, ppcle, ppc64, ppc64le, mips, mipsle, misp64, wasm]
+   #     # goos: [darwin, js, linux, windows]
+   #     goarch: [arm64, amd64]
+   #     goos: [darwin, linux, windows]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,6 +34,8 @@ jobs:
 
       - name: Run make build
         env:
-          GOARCH: ${{ matrix. goarch }}
-          GOOS: ${{ matrix. goos }}
+        #  GOARCH: ${{ matrix. goarch }}
+        #  GOOS: ${{ matrix. goos }}
+          GOARCH: arm64
+          GOOS: darwin
         run: make build

--- a/.github/workflows/cross-build.yaml
+++ b/.github/workflows/cross-build.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Cross build
 
 on:
   push:
@@ -7,12 +7,16 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  cross-build:
+    runs-on: unbuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        arch: [x86_64, aarch64, loongarch64, powerpc64le, wasm]
+        # Ideally would test all the combinations, but this is quite slow and overwhelm Github, so
+        # we use a subset.
+        # goarch: [arm64, amd64, riscv, riscv64, loong64, ppc, ppcle, ppc64, ppc64le, mips, mipsle, misp64, wasm]
+        # goos: [darwin, js, linux, windows]
+        goarch: [arm64, amd64]
+        goos: [darwin, linux, windows]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,4 +33,7 @@ jobs:
         shell: powershell
 
       - name: Run make build
+        env:
+          GOARCH: ${{ matrix. goarch }}
+          GOOS: ${{ matrix. goos }}
         run: make build

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,6 +18,9 @@ endif
 GO111MODULE=on
 export GO111MODULE
 
+GOOS ?= $(shell go env GOOS)
+export GOOS
+
 .PHONY: help
 help:
 	@echo "Usage: make [target]"
@@ -31,23 +34,37 @@ format-c: ## formats all the C code
 format-c-check: ## checks C code formatting
 	./scripts/format-c-check
 
+.PHONY: clean
+clean: ## clean up builds
+	@rm -rf .build
+
 .PHONY: build
-build: ## builds the Linux dynamic libraries and leave them and a copy of the definitions in .build directory
+build:  ## builds the libraries and leave them and a copy of the definitions in .build directory
 ifeq (${GPL2},true)
 	cp go.mod go-gpl2.mod
 	cp go.sum go-gpl2.sum
 	go mod edit -replace github.com/spacemonkeygo/monkit/v3=./internal/replacements/monkit
 	./scripts/check-licenses-gpl2
 endif
-	go build -ldflags="-s -w" -buildmode c-shared -o .build/uplink.so .
-	go build -ldflags="-s -w" -buildmode c-archive -o .build/uplink.a .
-	mv .build/uplink.so .build/libuplink.so
-	mv .build/uplink.a .build/libuplink.a
+	mkdir -p .build/out/
+
+	./scripts/build-lib .build/out/
+
+# Move the possible build artifacts
+	@(mv .build/out/uplink.so .build/libuplink.so || true)
+	@(mv .build/out/uplink.a .build/libuplink.a || true)
+	@(mv .build/out/uplink.dll .build/libuplink.dll || true)
+	@(mv .build/out/uplink.lib .build/libuplink.lib || true)
+	@(mv .build/out/uplink.dylib .build/libuplink.dylib || true)
+
 	mkdir -p .build/uplink
-	mv .build/*.h .build/uplink
+	mv .build/out/*.h .build/uplink
 	cp uplink_definitions.h .build/uplink
 	cp uplink_compat.h .build/uplink
-	./scripts/gen-pkg-config > .build/libuplink.pc
+
+	if [ "${GOOS}" != "windows" ]; then \
+		./scripts/gen-pkg-config > .build/libuplink.pc; \
+	fi
 
 .PHONY: bump-dependencies
 bump-dependencies: ## bumps the dependencies
@@ -84,6 +101,7 @@ install: build ## install library and headers
 OS ?= $(shell uname)
 ZIG ?= $(shell which zig)
 TAG ?= $(shell git tag -l | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n 1)
+
 
 .PHONY: release-files
 release-files: ## builds and copies release files to Github

--- a/scripts/build-lib
+++ b/scripts/build-lib
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+_print_usage() {
+	echo "Usage: $0 OUT_DIR"
+}
+
+if [ -z "$1" ]; then
+	_print_usage
+	exit 1
+fi
+OUT_DIR=$1
+
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+ZIG=$(which zig)
+
+HOST_GOOS=$(uname | tr '[:upper:]' '[:lower:]')
+HOST_GOARCH=$(uname -m)
+
+if [ "${GOOS}" = "darwin" ]; then
+	if [ "${HOST_GOOS}" != "darwin" ]; then
+		@echo "Cannot cross-compile from $HOST_GOOS to $GOOS.";
+		exit 1
+	fi
+fi
+
+# Normalize HOST_GOARCH
+if [ "${HOST_GOARCH}" = "x86_64" ]; then
+	HOST_GOARCH="amd64"
+elif [ "${HOST_GOARCH}" = "aarch64" ]; then
+	HOST_GOARCH="arm64"
+elif [ "${HOST_GOARCH}" = "loongarch64" ]; then
+	HOST_GOARCH="loong64"
+fi
+
+# Initialize variables
+OUT_SHARED_NAME="uplink.so"
+OUT_STATIC_NAME="uplink.a"
+CC_TARGET=""
+
+if [ "$GOOS-$GOARCH" = "$HOST_GOOS-$HOST_GOARCH" ]; then
+	CC_TARGET=""
+	case "$GOOS" in
+		darwin)
+			OUT_SHARED_NAME="uplink.dylib"
+			;;
+		windows)
+			OUT_SHARED_NAME="uplink.dll"
+			OUT_STATIC_NAME="uplink.lib"
+			;;
+	esac
+else
+	if [ -z "$ZIG" ]; then
+		echo "Zig compiler not found"
+		exit 1
+	fi
+
+	echo "Cross-compiling to target: $GOOS-$GOARCH (host: $HOST_GOOS-$HOST_GOARCH)"
+
+	CC_ARCH=""
+	case "$GOARCH" in
+		amd64) CC_ARCH="x86_64" ;;
+		arm64) CC_ARCH="aarch64" ;;
+		riscv) CC_ARCH="riscv32" ;;
+		riscv64) CC_ARCH="riscv64" ;;
+		loong64) CC_ARCH="loongarch64" ;;
+		ppc) CC_ARCH="powerpc" ;;
+		ppcle) CC_ARCH="powerpcle" ;;
+		ppc64) CC_ARCH="powerpc64" ;;
+		ppc64le) CC_ARCH="powerpc64le" ;;
+		mips) CC_ARCH="mips" ;;
+		mipsle) CC_ARCH="mipsle" ;;
+		mips64) CC_ARCH="mips64" ;;
+		mips64le) CC_ARCH="mips64le" ;;
+		wasm) CC_ARCH="wasm" ;;
+		*)
+			echo "Unrecognized cross-compilation target: GOOS=$GOOS GOARCH=$GOARCH" >&2
+			exit 1
+			;;
+	esac
+
+	case "$GOOS" in
+		linux) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-linux-gnu" ;;
+		darwin)
+			# Native compilation is required for MacOS
+			CC_TARGET=""
+			OUT_SHARED_NAME="uplink.dylib"
+			;;
+		windows)
+			CC_TARGET="${ZIG} cc -target ${CC_ARCH}-windows"
+			OUT_SHARED_NAME="uplink.dll"
+			OUT_STATIC_NAME="uplink.lib"
+			;;
+		js) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-wasi" ;;
+		*) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-${GOOS}" ;;
+	esac
+fi
+
+OUT_SHARED_PATH="$OUT_DIR/$OUT_SHARED_NAME"
+OUT_STATIC_PATH="$OUT_DIR/$OUT_STATIC_NAME"
+
+if [ -z "$CC_TARGET" ]; then
+	set -e -x
+	CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode c-shared -o "$OUT_SHARED_PATH" .
+	CGO_ENABLED=1 go build -ldflags="-s -w" -buildmode c-archive -o "$OUT_STATIC_PATH" .
+else
+	set -e -x
+	CGO_ENABLED=1 CC="$CC_TARGET" go build -ldflags="-s -w" -buildmode c-shared -o "$OUT_SHARED_PATH" .
+	CGO_ENABLED=1 CC="$CC_TARGET" go build -ldflags="-s -w" -buildmode c-archive -o "$OUT_STATIC_PATH" .
+fi

--- a/scripts/build-lib
+++ b/scripts/build-lib
@@ -19,7 +19,7 @@ HOST_GOARCH=$(uname -m)
 
 if [ "${GOOS}" = "darwin" ]; then
 	if [ "${HOST_GOOS}" != "darwin" ]; then
-		@echo "Cannot cross-compile from $HOST_GOOS to $GOOS.";
+		echo "Cannot cross-compile from $HOST_GOOS to $GOOS.";
 		exit 1
 	fi
 fi


### PR DESCRIPTION
This change makes `make build` capable of cross-compiling. This can be
useful for external libraries.