### PR TITLE
scripts: Drop JS target because it isn't supported

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -50,6 +50,8 @@ endif
 
 	./scripts/build-lib .build/out/
 
+	ls -lah .build/out/
+
 # Move the possible build artifacts, silently discarding mv errors
 	(mv .build/out/uplink.so .build/libuplink.so 2>/dev/null || true)
 	(mv .build/out/uplink.a .build/libuplink.a 2>/dev/null || true)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ ifeq (${GPL2},true)
 endif
 	mkdir -p .build/out/
 
-	./scripts/build-lib .build/out/
+	./scripts/build-lib .build/out
 
 	ls -lah .build/out/
 

--- a/scripts/build-lib
+++ b/scripts/build-lib
@@ -86,8 +86,8 @@ else
 	esac
 fi
 
-OUT_SHARED_PATH=$(realpath "$OUT_DIR/$OUT_SHARED_NAME")
-OUT_STATIC_PATH=$(realpath "$OUT_DIR/$OUT_STATIC_NAME")
+OUT_SHARED_PATH="$OUT_DIR/$OUT_SHARED_NAME"
+OUT_STATIC_PATH="$OUT_DIR/$OUT_STATIC_NAME"
 
 if [ -z "$CC_TARGET" ]; then
 	set -e -x

--- a/scripts/build-lib
+++ b/scripts/build-lib
@@ -82,7 +82,6 @@ else
 			OUT_SHARED_NAME="uplink.dll"
 			OUT_STATIC_NAME="uplink.lib"
 			;;
-		js) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-wasi" ;;
 		*) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-${GOOS}" ;;
 	esac
 fi


### PR DESCRIPTION
On PR https://github.com/storj/uplink-c/pull/30 we added the
cross-compilation capabilities, but we found out that we cannot compile
to JS, and we forgot to remove the target from the build script.

This commit removes the JS target from it.