### PR TITLE
scripts: Revert realpath because it breaks OSX build

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ ifeq (${GPL2},true)
 endif
 	mkdir -p .build/out/
 
-	./scripts/build-lib .build/out/
+	./scripts/build-lib .build/out
 
 # Move the possible build artifacts, silently discarding mv errors
 	(mv .build/out/uplink.so .build/libuplink.so 2>/dev/null || true)

--- a/scripts/build-lib
+++ b/scripts/build-lib
@@ -87,8 +87,8 @@ else
 	esac
 fi
 
-OUT_SHARED_PATH=$(realpath "$OUT_DIR/$OUT_SHARED_NAME")
-OUT_STATIC_PATH=$(realpath "$OUT_DIR/$OUT_STATIC_NAME")
+OUT_SHARED_PATH="$OUT_DIR/$OUT_SHARED_NAME"
+OUT_STATIC_PATH="$OUT_DIR/$OUT_STATIC_NAME"
 
 if [ -z "$CC_TARGET" ]; then
 	set -e -x


### PR DESCRIPTION
Revert "scripts: Use realpath to suppress double path separator" commit and remove the leading path separator from the Makefile to not have a path with empty parts.

I found out that the build breaks on OSX with Github actions, no idea, why it worked on yesterday PR.

This reverts commit d404c755d5e2fad370ce715429bbcd2f1099e24e.