### PR TITLE
scripts: Drop JS target because it isn't supported

### DIFF
--- a/scripts/build-lib
+++ b/scripts/build-lib
@@ -82,7 +82,6 @@ else
 			OUT_SHARED_NAME="uplink.dll"
 			OUT_STATIC_NAME="uplink.lib"
 			;;
-		js) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-wasi" ;;
 		*) CC_TARGET="${ZIG} cc -target ${CC_ARCH}-${GOOS}" ;;
 	esac
 fi


### PR DESCRIPTION
On PR https://github.com/storj/uplink-c/pull/30 we added the cross-compilation capabilities, but we found out that we cannot compile to JS and we forgot to remove the target from the build script. This commit remove the JS target from it.

Change-Id: Id2c610b1fe2ef56e472c0f282a43e88059e12d12