### PR TITLE
ci: deploy doxygen docs to GitHub Pages on tag push

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,70 @@
+name: Deploy Docs
+
+on:
+  # Runs when a new version tag is pushed
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+
+  # Validates doc builds on pull requests (without deploying)
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job — always runs, so PRs and main pushes verify the docs still build.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install Zig compiler
+        uses: mlugg/setup-zig@v2
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+      - name: Install doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen
+      - name: Generate documentation
+        env:
+          PROJECT_NUMBER: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        run: ./docs/generate.sh
+      - name: Setup Pages
+        if: github.ref_type == 'tag'
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        if: github.ref_type == 'tag'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/gh-pages
+
+  # Deployment job — only runs for tag pushes.
+  deploy:
+    if: github.ref_type == 'tag'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/docs/generate.sh
+++ b/docs/generate.sh
@@ -13,11 +13,14 @@ cd $(dirname "$0")
 PROJECT_ROOT=$(realpath ..)
 
 ## checkout gh-pages branch here
-if [ ! -d gh-pages ] ; then
-    git clone git@github.com:storj/uplink-c.git gh-pages --branch gh-pages
-else
-    cd gh-pages
-    git pull
+## skipped in CI, where the output is deployed via GitHub Pages actions instead.
+if [ -z "$CI" ] ; then
+    if [ ! -d gh-pages ] ; then
+        git clone git@github.com:storj/uplink-c.git gh-pages --branch gh-pages
+    else
+        cd gh-pages
+        git pull
+    fi
 fi
 
 cd $PROJECT_ROOT
@@ -49,4 +52,5 @@ cp README.md .build/README.md
 sed --in-place -r 's~\[(.+)\]\(([^h].+)\)~[\1](https://github.com/storj/uplink-c/tree/main/\2)~g' .build/README.md
 
 ## generate docs
-doxygen docs/Doxyfile
+## PROJECT_NUMBER can be overridden via env var (e.g. by CI to use the current tag).
+(cat docs/Doxyfile; [ -n "$PROJECT_NUMBER" ] && echo "PROJECT_NUMBER=$PROJECT_NUMBER") | doxygen -


### PR DESCRIPTION
Adds a workflow that generates the doxygen docs and deploys them to
GitHub Pages whenever a v* tag is pushed (or via manual dispatch).
Skips the local gh-pages clone step in generate.sh when running in CI,
and lets PROJECT_NUMBER be overridden via env var so the deployed docs
reflect the tag being built.

Fixes #12
